### PR TITLE
Refactor into separate routes

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,7 +39,7 @@ export const addNote = async (title, content) => {
 
   // Add the file content to "IPFS"
   ipfsStore.update(ipfs => {
-    ipfs.contentCid = content;
+    ipfs[contentCid] = content;
     return ipfs;
   });
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -29,7 +29,7 @@ export const addNote = async (title, content) => {
 
   // Add the memo and content to the sphere
   sphereStore.update(sphere => {
-    sphere.links[title] = memoCID;
+    sphere.links[title.toLowerCase().replaceAll(" ", "-")] = memoCID;
     return sphere;
   });
   sphereStore.update(sphere => {
@@ -44,16 +44,13 @@ export const addNote = async (title, content) => {
   });
 };
 
+// Generate Seed Data for the sphere so the page doesn't start blank
 export const populateSphere = async () => {
-  console.log('populate the sphere');
-
-  // Generate Seed Data
-
   // Set up the first sphere
   sphereStore.update(sphere => ({ ...sphere, title: "Bob's Notebook" }));
   sphereStore.update(sphere => ({ ...sphere, name: "bob" }));
 
-  // Let's have some notes
+  // Let's add some notes
   let catThoughts = 'I love cats. I love every kind of cat.';
   let animalNotes = 'I have strongly felt /cat-thoughts\n\n Dogs are just okay';
   await addNote('cat-thoughts', catThoughts);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,61 @@
+import { CID } from 'multiformats/cid';
+import * as json from 'multiformats/codecs/json';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { base64 } from 'multiformats/bases/base64';
+
+import { sphereStore, ipfsStore } from '../stores';
+
+export const generateCidFromObject = async (data) => {
+  const bytes = json.encode(data);
+  const hash = await sha256.digest(bytes);
+  const cid = CID.create(1, json.code, hash);
+  return cid.toString(base64.encoder);
+};
+
+export const addNote = async (title, content) => {
+  console.log('a note is being added');
+  const contentCid = await generateCidFromObject(content);
+
+  // Create the memo
+  const memo = {
+    parentCID: null, // This is a new note - no previous version
+    headers: {
+      Title: title,
+      Created: new Date().getTime()
+    },
+    contentCID: contentCid
+  };
+  const memoCID = await generateCidFromObject(memo);
+
+  // Add the memo and content to the sphere
+  sphereStore.update(sphere => {
+    sphere.links[title] = memoCID;
+    return sphere;
+  });
+  sphereStore.update(sphere => {
+    sphere.notes[memoCID] = memo;
+    return sphere;
+  });
+
+  // Add the file content to "IPFS"
+  ipfsStore.update(ipfs => {
+    ipfs.contentCid = content;
+    return ipfs;
+  });
+};
+
+export const populateSphere = async () => {
+  console.log('populate the sphere');
+
+  // Generate Seed Data
+
+  // Set up the first sphere
+  sphereStore.update(sphere => ({ ...sphere, title: "Bob's Notebook" }));
+  sphereStore.update(sphere => ({ ...sphere, name: "bob" }));
+
+  // Let's have some notes
+  let catThoughts = 'I love cats. I love every kind of cat.';
+  let animalNotes = 'I have strongly felt /cat-thoughts\n\n Dogs are just okay';
+  await addNote('cat-thoughts', catThoughts);
+  await addNote('animal-thoughts', animalNotes);
+}

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,0 +1,11 @@
+export const csr = true
+export const ssr = false
+export const prerender = true
+
+import { populateSphere } from '../lib/utils';
+
+/** @type {import('./$types').LayoutLoad} */
+export function load() {
+  console.log('load');
+  populateSphere();
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,5 +3,7 @@
 </script>
 
 <div class="mx-2">
+	<h1 class="text-4xl my-5"><a href="/">Noosphere Simulator</a></h1>
+
 	<slot />
 </div>

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,0 +1,6 @@
+import { populateSphere } from '../lib/utils';
+
+export function load() {
+  console.log('load');
+  populateSphere();
+}

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,6 +1,0 @@
-import { populateSphere } from '../lib/utils';
-
-export function load() {
-  console.log('load');
-  populateSphere();
-}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,128 +1,69 @@
 <script>
-	console.log('+page.svelte is loading...');
-
-	import { onMount } from 'svelte';
-	import { populateSphere, addNote } from '../lib/utils';
-	import { sphereStore as sphere, ipfsStore } from '../stores';
+	import { addNote } from '../lib/utils';
+	import { sphereStore as sphere } from '../stores';
 
 	// View-related stuff
-	let currentNote = '';
-	let currentView = 'note';
 	let createNew = false;
 
 	// in-page variables
-	let newNoteTitle = '';
-	let newNoteContent = '';
+	let newSphereTitle = '';
+	let newSphereName = '';
 
-	const addNewNote = async (title, content) => {
-		await addNote(newNoteTitle, newNoteContent);
+	const addNewSphere = async (title, content) => {
+		await addSphere(newSphereTitle, newSphereContent);
 
-		newNoteTitle = '';
-		newNoteContent = '';
-	};
-
-	let sphereStore = {};
-	const unsubscribeSphere = sphere.subscribe((value) => {
-		sphereStore = value;
-	});
-
-	let ipfs;
-	const unsubscribeIpfs = ipfsStore.subscribe((value) => {
-		ipfs = value;
-	});
-
-	const fetchNote = (currentNote) => {
-		const noteCID = sphereStore.links[currentNote];
-		return sphereStore.notes[noteCID];
-	};
-
-	const fetchNoteContent = (currentNote) => {
-		const noteCID = sphereStore.links[currentNote];
-		const contentCID = sphereStore.notes[noteCID].contentCID;
-		console.log('fetching note content');
-		return ipfs[contentCID];
+		newSphereTitle = '';
+		newSphereName = '';
 	};
 </script>
 
-<h2>Notebooks</h2>
-
 <div class="bg-slate-200">
-	{#if currentView === 'note'}
-		{#if currentNote === null || currentNote === ''}
-			<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
-				{$sphere.title} • Notes
-			</h2>
-			<ul>
-				{#each Object.entries($sphere.links) as [linkCID, noteCID]}
-					<li class="p-1 px-2 font-mono">
-						<a href on:click={() => (currentNote = linkCID)}>/{linkCID}</a>
-					</li>
-				{/each}
-				{#if createNew}
-					<li class="p-1 px-2 border-t-2 border-white font-mono">
-						<p class="mb-2">New Note</p>
-						<input
-							placeholder="New note title..."
-							type="text"
-							class="px-2 w-3/4 mb-2"
-							bind:value={newNoteTitle}
-						/>
-						<div class="w-3/4 flex items-stretch">
-							<div class="px-2 w-full break-words invisible" />
-							<textarea
-								placeholder="New note content"
-								class="px-2 w-full resize-none overflow-hidden h-auto ml-[-100%]"
-								onInput="this.previousElementSibling.innerText = this.value + String.fromCharCode(10)"
-								bind:value={newNoteContent}
-							/>
-						</div>
-						<input
-							on:click={addNewNote}
-							type="submit"
-							class="mt-2 font-mono hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
-							value="Add Note"
-						/>
-						<!-- cancel button -->
-						<button
-							class="hover:cursor-pointer px-2 border-slate-800 hover:bg-slate-300"
-							on:click={() => (createNew = false)}>Cancel</button
-						>
-					</li>
-				{:else}
-					<li class="p-1 px-2 font-mon">
-						<button
-							class="hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
-							on:click={() => (createNew = true)}>Create new note</button
-						>
-					</li>
-				{/if}
-			</ul>
-		{:else if $sphere.links[currentNote]}
-			<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
-				{$sphere.title} • /{currentNote} ({$sphere.links[currentNote]})
-			</h2>
-			<p class="p-1 px-2 font-mono border-white border-b-2">
-				{fetchNoteContent(currentNote)}
-			</p>
-			<h3 class="px-2 p-1 font-mono font-semibold underline">Memo</h3>
-			<div class="p-1 px-2 font-mono flex items-center">
-				<div class="bg-purple-200 border border-purple-600 rounded-full w-16 h-32 box-content ">
-					<div class="bg-purple-400 border-2 border-purple-900 rounded-full w-6 h-6 mx-5 my-2" />
-					<div class="bg-cyan-300 border-2 border-cyan-800 rounded-full w-10 h-10 m-3" />
-					<div class="bg-purple-400 border-2 border-purple-900 rounded-full w-6 h-6 mx-5 my-2" />
+	<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">Spheres</h2>
+	<ul>
+		<li class="p-1 px-2 font-mono">
+			<a href="/notebooks/bob">Bob's Notebook</a>
+		</li>
+		<!-- {#each Object.entries($sphere.links) as [linkCID, noteCID]}
+			<li class="p-1 px-2 font-mono">
+				<a href="/notebooks/bob/notes/{linkCID}">/{linkCID}</a>
+			</li>
+		{/each} -->
+		{#if createNew}
+			<li class="p-1 px-2 border-t-2 border-white font-mono">
+				<p class="mb-2">New Sphere</p>
+				<input
+					placeholder="New sphere title..."
+					type="text"
+					class="px-2 w-3/4 mb-2"
+					bind:value={newSphereTitle}
+				/>
+				<div>
+					<input
+						placeholder="New sphere name..."
+						type="text"
+						class="px-2 w-3/4 mb-2"
+						bind:value={newSphereName}
+					/>
 				</div>
-				<div class="h-32 ">
-					<div class="mx-5 my-2">Parent CID: {fetchNote(currentNote).parentCID}</div>
-					<div class="mx-5 h-10 m-3 flex items-center">
-						Inline Headers: &#123;{Object.entries(fetchNote(currentNote).headers)}&#125;
-					</div>
-					<div class="mx-5 my-2">Content CID: {fetchNote(currentNote).contentCID}</div>
-				</div>
-			</div>
+				<input
+					on:click={addNewSphere}
+					type="submit"
+					class="mt-2 font-mono hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
+					value="Add Sphere"
+				/>
+				<!-- cancel button -->
+				<button
+					class="hover:cursor-pointer px-2 border-slate-800 hover:bg-slate-300"
+					on:click={() => (createNew = false)}>Cancel</button
+				>
+			</li>
 		{:else}
-			{console.log(currentNote)}
+			<li class="p-1 px-2 font-mon">
+				<button
+					class="hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
+					on:click={() => (createNew = true)}>Create new sphere</button
+				>
+			</li>
 		{/if}
-	{:else if currentView == ''}
-		nothing
-	{/if}
+	</ul>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
 
 	import { onMount } from 'svelte';
 	import { populateSphere, addNote } from '../lib/utils';
-	import { sphereStore as sphere, ipfsStore as ipfs } from '../stores';
+	import { sphereStore as sphere, ipfsStore } from '../stores';
 
 	// View-related stuff
 	let currentNote = '';
@@ -21,14 +21,25 @@
 		newNoteContent = '';
 	};
 
+	let sphereStore = {};
+	const unsubscribeSphere = sphere.subscribe((value) => {
+		sphereStore = value;
+	});
+
+	let ipfs;
+	const unsubscribeIpfs = ipfsStore.subscribe((value) => {
+		ipfs = value;
+	});
+
 	const fetchNote = (currentNote) => {
-		const noteCID = sphere.links[currentNote];
-		return sphere.notes[noteCID];
+		const noteCID = sphereStore.links[currentNote];
+		return sphereStore.notes[noteCID];
 	};
 
 	const fetchNoteContent = (currentNote) => {
-		const noteCID = sphere.links[currentNote];
-		const contentCID = sphere.notes[noteCID].contentCID;
+		const noteCID = sphereStore.links[currentNote];
+		const contentCID = sphereStore.notes[noteCID].contentCID;
+		console.log('fetching note content');
 		return ipfs[contentCID];
 	};
 </script>

--- a/src/routes/layout.js
+++ b/src/routes/layout.js
@@ -1,3 +1,0 @@
-export const csr = true
-export const ssr = false
-export const prerender = true

--- a/src/routes/notebooks/[name]/+page.js
+++ b/src/routes/notebooks/[name]/+page.js
@@ -1,0 +1,12 @@
+// import { error } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageLoad} */
+export function load({ params }) {
+  // Look up the name in the spheres to see if it exists
+  return {
+    name: params.name,
+  };
+
+  // If it doesn't exist, throw an error
+  // throw error(404, 'Not found');
+}

--- a/src/routes/notebooks/[name]/+page.svelte
+++ b/src/routes/notebooks/[name]/+page.svelte
@@ -1,8 +1,70 @@
 <script>
-	/** @type {import('./$types').PageData} */
-	export let data;
+	import { addNote } from '/src/lib/utils';
+	import { sphereStore as sphere } from '/src/stores';
+
+	// View-related stuff
+	let currentNote = '';
+	let createNew = false;
+
+	// in-page variables
+	let newNoteTitle = '';
+	let newNoteContent = '';
+
+	const addNewNote = async (title, content) => {
+		await addNote(newNoteTitle, newNoteContent);
+
+		newNoteTitle = '';
+		newNoteContent = '';
+	};
 </script>
 
-<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
-	{data.name}'s Notebook • Notes
-</h2>
+<div class="bg-slate-200">
+	<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
+		{$sphere.title} • Notes
+	</h2>
+	<ul>
+		{#each Object.entries($sphere.links) as [linkCID, noteCID]}
+			<li class="p-1 px-2 font-mono">
+				<a href="/notebooks/bob/notes/{linkCID}">/{linkCID}</a>
+			</li>
+		{/each}
+		{#if createNew}
+			<li class="p-1 px-2 border-t-2 border-white font-mono">
+				<p class="mb-2">New Note</p>
+				<input
+					placeholder="New note title..."
+					type="text"
+					class="px-2 w-3/4 mb-2"
+					bind:value={newNoteTitle}
+				/>
+				<div class="w-3/4 flex items-stretch">
+					<div class="px-2 w-full break-words invisible" />
+					<textarea
+						placeholder="New note content"
+						class="px-2 w-full resize-none overflow-hidden h-auto ml-[-100%]"
+						onInput="this.previousElementSibling.innerText = this.value + String.fromCharCode(10)"
+						bind:value={newNoteContent}
+					/>
+				</div>
+				<input
+					on:click={addNewNote}
+					type="submit"
+					class="mt-2 font-mono hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
+					value="Add Note"
+				/>
+				<!-- cancel button -->
+				<button
+					class="hover:cursor-pointer px-2 border-slate-800 hover:bg-slate-300"
+					on:click={() => (createNew = false)}>Cancel</button
+				>
+			</li>
+		{:else}
+			<li class="p-1 px-2 font-mon">
+				<button
+					class="hover:cursor-pointer border-2 px-2 border-slate-800 hover:bg-slate-300"
+					on:click={() => (createNew = true)}>Create new note</button
+				>
+			</li>
+		{/if}
+	</ul>
+</div>

--- a/src/routes/notebooks/[name]/+page.svelte
+++ b/src/routes/notebooks/[name]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
+	{data.name}'s Notebook • Notes
+</h2>

--- a/src/routes/notebooks/[name]/notes/[title]/+page.js
+++ b/src/routes/notebooks/[name]/notes/[title]/+page.js
@@ -1,0 +1,15 @@
+// import { error } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageLoad} */
+export function load({ params }) {
+  // Look up the name in the spheres to see if it exists
+
+  console.log(params);
+  return {
+    name: params.name,
+    title: params.title,
+  };
+
+  // If it doesn't exist, throw an error
+  // throw error(404, 'Not found');
+}

--- a/src/routes/notebooks/[name]/notes/[title]/+page.svelte
+++ b/src/routes/notebooks/[name]/notes/[title]/+page.svelte
@@ -1,9 +1,59 @@
 <script>
-	let sphere = {
-		title: "Bob's Notebook"
+	/** @type {import('./$types').PageData} */
+	import { onDestroy } from 'svelte';
+	import { sphereStore as sphere, ipfsStore } from '/src/stores';
+
+	export let data;
+	let currentNote = data.title;
+
+	let sphereStore = {};
+	const unsubscribeSphere = sphere.subscribe((value) => {
+		sphereStore = value;
+	});
+
+	let ipfs;
+	const unsubscribeIpfs = ipfsStore.subscribe((value) => {
+		ipfs = value;
+	});
+
+	const fetchNote = (currentNote) => {
+		const noteCID = sphereStore.links[currentNote];
+		return sphereStore.notes[noteCID];
 	};
+
+	const fetchNoteContent = (currentNote) => {
+		const noteCID = sphereStore.links[currentNote];
+		const contentCID = sphereStore.notes[noteCID].contentCID;
+		console.log('fetching note content');
+		return ipfs[contentCID];
+	};
+
+	onDestroy(() => {
+		unsubscribeSphere();
+		unsubscribeIpfs();
+	});
 </script>
 
-<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
-	{sphere.title} • Notes
-</h2>
+<div class="bg-slate-200">
+	<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
+		{$sphere.title} • /{currentNote} ({$sphere.links[currentNote]})
+	</h2>
+	<p class="p-1 px-2 font-mono border-white border-b-2">
+		{fetchNoteContent(currentNote)}
+	</p>
+	<h3 class="px-2 p-1 font-mono font-semibold underline">Memo</h3>
+	<div class="p-1 px-2 font-mono flex items-center">
+		<div class="bg-purple-200 border border-purple-600 rounded-full w-16 h-32 box-content ">
+			<div class="bg-purple-400 border-2 border-purple-900 rounded-full w-6 h-6 mx-5 my-2" />
+			<div class="bg-cyan-300 border-2 border-cyan-800 rounded-full w-10 h-10 m-3" />
+			<div class="bg-purple-400 border-2 border-purple-900 rounded-full w-6 h-6 mx-5 my-2" />
+		</div>
+		<div class="h-32 ">
+			<div class="mx-5 my-2">Parent CID: {fetchNote(currentNote).parentCID}</div>
+			<div class="mx-5 h-10 m-3 flex items-center">
+				Inline Headers: &#123;{Object.entries(fetchNote(currentNote).headers)}&#125;
+			</div>
+			<div class="mx-5 my-2">Content CID: {fetchNote(currentNote).contentCID}</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/notebooks/[name]/notes/[title]/+page.svelte
+++ b/src/routes/notebooks/[name]/notes/[title]/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	let sphere = {
+		title: "Bob's Notebook"
+	};
+</script>
+
+<h2 class="border-b-2 p-1 px-2 border-white font-mono font-normal text-sm italic">
+	{sphere.title} • Notes
+</h2>

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,0 +1,11 @@
+import { writable } from 'svelte/store'
+
+export const sphereStore = writable({
+  name: "",
+  title: "",
+  links: {},
+  notes: {},
+  names: []
+})
+
+export const ipfsStore = writable({})


### PR DESCRIPTION
This PR refactors the code significantly to make way for future features:

- [x] proper routes with appropriate slugs
- [x] move the seed data into it's own function
- [x] move shared code into `lib/utils.js`
- [x] move shared state into stores